### PR TITLE
Add OS-based SDL2 library detection

### DIFF
--- a/lib/doomfire.rb
+++ b/lib/doomfire.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'doomfire/platform'
 require 'doomfire/base'
 require 'doomfire/terminal'
 require 'doomfire/spinner'

--- a/lib/doomfire/ffi_sdl.rb
+++ b/lib/doomfire/ffi_sdl.rb
@@ -8,7 +8,7 @@ module Doomfire
   module FFI_SDL
     extend Fiddle::Importer
 
-    dlload "libSDL2.#{Platform.lib_ext}"
+    dlload Platform.find_lib('libSDL2')
 
     typealias 'Uint32', :int
     typealias 'Uint16', :int

--- a/lib/doomfire/ffi_sdl.rb
+++ b/lib/doomfire/ffi_sdl.rb
@@ -8,7 +8,7 @@ module Doomfire
   module FFI_SDL
     extend Fiddle::Importer
 
-    dlload 'libSDL2.dylib'
+    dlload "libSDL2.#{RbConfig::CONFIG['SOEXT']}"
 
     typealias 'Uint32', :int
     typealias 'Uint16', :int

--- a/lib/doomfire/ffi_sdl.rb
+++ b/lib/doomfire/ffi_sdl.rb
@@ -8,7 +8,7 @@ module Doomfire
   module FFI_SDL
     extend Fiddle::Importer
 
-    dlload "libSDL2.#{RbConfig::CONFIG['SOEXT']}"
+    dlload "libSDL2.#{Platform.lib_ext}"
 
     typealias 'Uint32', :int
     typealias 'Uint16', :int

--- a/lib/doomfire/platform.rb
+++ b/lib/doomfire/platform.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Doomfire
+  module Platform
+    module_function
+
+    def lib_ext
+      RbConfig::CONFIG['SOEXT']
+    end
+
+    def unix?
+      RbConfig::CONFIG['host_os'].match?(/(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix|hpux)/i)
+    end
+  end
+end

--- a/lib/doomfire/platform.rb
+++ b/lib/doomfire/platform.rb
@@ -4,12 +4,33 @@ module Doomfire
   module Platform
     module_function
 
+    def find_lib(library_name)
+      library = "#{library_name}.#{lib_ext}"
+
+      possible_locations = [
+        # Ubuntu 20.04 LTS
+        '/usr/lib/x86_64-linux-gnu'
+      ]
+
+      possible_locations << File.join(`brew --prefix sdl2`.chomp, 'lib') if homebrew_installed?
+
+      Dir.glob(
+        possible_locations.map do |path|
+          File.expand_path(File.join(path, library))
+        end
+      ).first
+    end
+
     def lib_ext
       RbConfig::CONFIG['SOEXT']
     end
 
     def unix?
       RbConfig::CONFIG['host_os'].match?(/(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix|hpux)/i)
+    end
+
+    def homebrew_installed?
+      ENV['PATH'].include?('homebrew/bin')
     end
   end
 end

--- a/lib/doomfire/window_size.rb
+++ b/lib/doomfire/window_size.rb
@@ -3,7 +3,7 @@
 module Doomfire
   class WindowSize
     def terminal_width
-      return 80 unless unix?
+      return 80 unless Platform.unix?
 
       result = dynamic_width
       result < 20 ? 80 : result
@@ -44,10 +44,6 @@ module Doomfire
 
     def dynamic_width_tput
       `tput cols 2>/dev/null`.to_i
-    end
-
-    def unix?
-      RUBY_PLATFORM =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix|hpux)/i
     end
   end
 end

--- a/spec/terminal_spec.rb
+++ b/spec/terminal_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Doomfire::Terminal do
   let!(:terminal) { Doomfire::Terminal.new }
 
-  before { RUBY_PLATFORM = 'windows' }
+  before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('windows') }
 
   describe '#clear_screen' do
     let(:output) { capture(:stdout) { terminal.send(:clear_screen) } }

--- a/spec/window_size_spec.rb
+++ b/spec/window_size_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Doomfire::WindowSize do
 
   describe '#terminal_width' do
     context 'unknown terminal' do
-      before { RUBY_PLATFORM = 'windows' }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('windows') }
 
       it 'returns 80 on unknown terminals' do
         expect(sizer.terminal_width).to eq 80


### PR DESCRIPTION
I came across https://github.com/marcinruszkiewicz/doomfire/issues/3 and thought I'd take a shot at it. 

Since this project doesn't use `ffi` I opted to not add the dependency here. This approach, however, does borrow some inspiration from [`FFI::Platform`](https://github.com/ffi/ffi/blob/master/lib/ffi/platform.rb).

Unfortunately I was a bit limited in testing this (using the `ubuntu` subsystem for Windows leads to an error since there's no X Window context - but I was able to verify these changes using Ruby 2.6 on a mac).

One thing of note, I'm not sure of where `libSDL2` may be installed on various OSs, but it should be straightforward to add to `possible_locations` where needed (or perhaps leverage an ENV variable to allow for some flexibility there).